### PR TITLE
fix: Increase token refresh buffer to 8 hours

### DIFF
--- a/lpai-backend/src/utils/ghlAuth.ts
+++ b/lpai-backend/src/utils/ghlAuth.ts
@@ -36,7 +36,7 @@ export function tokenNeedsRefresh(location: any): boolean {
   
   const expiresAt = new Date(location.ghlOAuth.expiresAt);
   const now = new Date();
-  const bufferTime = 60 * 60 * 1000; // 1 hour buffer - matches refresh-tokens.ts
+  const bufferTime = 8 * 60 * 60 * 1000; // 8 hour buffer  
   
   return (expiresAt.getTime() - now.getTime()) < bufferTime;
 }


### PR DESCRIPTION
- Change buffer from 1 hour to 8 hours to ensure tokens are refreshed before expiry
- Prevents invalid_grant errors when tokens expire between cron runs