### PR TITLE
fix: Keep contactId as string in conversation filter

### DIFF
--- a/lpai-backend/src/utils/filters.ts
+++ b/lpai-backend/src/utils/filters.ts
@@ -206,8 +206,7 @@ export function buildConversationFilter(params: ParsedQueryParams): any {
   if (params.locationId) filter.locationId = params.locationId;
   if (params.type) filter.type = params.type;
   if (params.contactId) {
-    filter.contactId = new ObjectId(params.contactId);
-  }
+    filter.contactId = params.contactId;   }
   
   // Unread only filter
   if (params.unreadOnly === 'true') {


### PR DESCRIPTION
- Fixed buildConversationFilter to not convert contactId to ObjectId
- Conversations now properly filter by contact
- Matches MongoDB schema where contactId is stored as string