### PR TITLE
feat: Move UserCreate to critical queue and add welcome emails

### DIFF
--- a/lpai-backend/src/utils/ghlAuth.ts
+++ b/lpai-backend/src/utils/ghlAuth.ts
@@ -37,7 +37,7 @@ export function tokenNeedsRefresh(location: any): boolean {
   
   const expiresAt = new Date(location.ghlOAuth.expiresAt);
   const now = new Date();
-  const bufferTime = 4 * 60 * 60 * 1000; // 4 hour buffer (changed from 8)
+  const bufferTime = 12 * 60 * 60 * 1000; // 12 hour buffer instead of 4
   
   return (expiresAt.getTime() - now.getTime()) < bufferTime;
 }

--- a/lpai-backend/src/utils/webhooks/router.ts
+++ b/lpai-backend/src/utils/webhooks/router.ts
@@ -111,7 +111,7 @@ export function analyzeWebhook(payload: any): any {
     case 'LocationCreate':
     case 'LocationUpdate':
       queueType = 'general';
-      priority = 4;
+      priority = 1;
       break;
 
     // Campaign events


### PR DESCRIPTION
- Route UserCreate webhooks to critical queue for immediate processing
- Add welcome email functionality to critical processor
- Generate setup tokens for new users
- Update token refresh buffer time