### PR TITLE
fix: migrate conversations/messages to use ObjectId references

### DIFF
--- a/docs/Conversations&Messages.md
+++ b/docs/Conversations&Messages.md
@@ -1,0 +1,373 @@
+# 📨 Conversations & Messages System - Complete Guide
+
+## 🎯 Why Two Collections?
+
+Think of it like **WhatsApp or iMessage**:
+- **Conversations** = The chat thread/room itself (like your chat with "Mom")
+- **Messages** = Individual texts within that chat
+
+This separation allows for:
+- Fast loading of conversation lists (without loading all messages)
+- Unread counts per conversation
+- Conversation-level features (starred, archived, muted)
+- Efficient pagination of messages
+
+## 🏗️ Architecture Overview
+
+```
+GoHighLevel (CRM)                    LPai App (MongoDB)
+┌─────────────────┐                 ┌─────────────────────┐
+│ Conversations   │ ──webhooks──→   │ conversations       │
+│ - SMS threads   │                 │ - Thread metadata   │
+│ - Email threads │                 │ - Unread counts     │
+│ - Call logs     │                 │ - Last message info │
+└─────────────────┘                 └─────────────────────┘
+        │                                      │
+        │                                      │
+┌─────────────────┐                 ┌─────────────────────┐
+│ Messages        │ ──webhooks──→   │ messages            │
+│ - SMS content   │                 │ - Full content      │
+│ - Email content │                 │ - Read status       │
+│ - Activities    │                 │ - Timestamps        │
+└─────────────────┘                 └─────────────────────┘
+```
+
+## 📊 Database Schema
+
+### conversations Collection
+```javascript
+{
+  _id: ObjectId("6856519a479e5bdcc186db5a"),        // MongoDB ID
+  ghlConversationId: "sSEd66uCPfGkM2nqfEjg",        // GHL's ID
+  locationId: "5OuaTrizW5wkZMI1xtvX",              // Tenant ID
+  
+  // Contact reference (NEW NAMING)
+  contactObjectId: ObjectId("6844d07b257a88ebfbd9be9b"), // MongoDB contact._id
+  ghlContactId: "Z66RBjrLBWWqmKP43eBR",            // GHL contact ID
+  
+  // Conversation metadata
+  type: "TYPE_PHONE",                                // TYPE_PHONE, TYPE_EMAIL, etc.
+  inbox: true,                                       // Is in inbox
+  starred: false,                                    // User starred it
+  unreadCount: 0,                                    // Number of unread messages
+  
+  // Last message preview (for list view)
+  lastMessageDate: ISODate("2025-06-24T03:55:21Z"),
+  lastMessageBody: "Test sms",                      // First 200 chars
+  lastMessageDirection: "outbound",                 // inbound/outbound
+  lastMessageType: "TYPE_SMS",
+  
+  // Contact info (denormalized for performance)
+  contactName: "Michael Dean",
+  contactEmail: "michael@example.com",
+  contactPhone: "+17603304890"
+}
+```
+
+### messages Collection
+```javascript
+{
+  _id: ObjectId("685a237ca3220ee53c1e3b0d"),
+  conversationId: ObjectId("6856519a479e5bdcc186db5a"), // MUST BE OBJECTID!
+  ghlMessageId: "3xHH82Tr2Uy68AP8PLTU",
+  ghlConversationId: "sSEd66uCPfGkM2nqfEjg",
+  locationId: "5OuaTrizW5wkZMI1xtvX",
+  
+  // Contact reference (NEW NAMING)
+  contactObjectId: ObjectId("6844d07b257a88ebfbd9be9b"), // MongoDB contact._id
+  ghlContactId: "Z66RBjrLBWWqmKP43eBR",            // GHL contact ID
+  
+  // Message details
+  type: 1,                                          // 1=SMS, 3=Email, 2=Call, 25+=Activities
+  messageType: "TYPE_SMS",                          // String version
+  direction: "outbound",                            // inbound/outbound
+  body: "Test sms",                                 // Message content
+  status: "sent",                                   // sent/delivered/failed
+  
+  // Metadata
+  dateAdded: ISODate("2025-06-24T03:10:05Z"),
+  read: true,
+  source: "app",                                    // app/ghl/webhook
+  sentBy: "68564ce27eb5e1b3a7f2e149",              // User who sent it
+  
+  // Email specific (type 3)
+  subject: "Your quote is ready",
+  emailMessageId: "abc123",                         // For fetching full content
+  needsContentFetch: true,                          // Email body not loaded yet
+  
+  // SMS specific (type 1)
+  fromNumber: "+17603304890",
+  toNumber: "+19097024889"
+}
+```
+
+## 🔑 Key Field Naming Convention
+
+To avoid confusion between MongoDB IDs and GHL IDs:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `contactObjectId` | ObjectId | MongoDB contact._id reference |
+| `ghlContactId` | String | GoHighLevel's contact ID |
+| `conversationId` | ObjectId | MongoDB conversation._id reference |
+| `ghlConversationId` | String | GoHighLevel's conversation ID |
+
+**Why this matters:**
+- `contactObjectId` as ObjectId = Fast queries and joins
+- Clear distinction between our IDs and GHL's IDs
+- No more confusion about what "contactId" means
+
+## 🔢 Message Types Reference
+
+```javascript
+const MESSAGE_TYPES = {
+  1: "SMS",
+  2: "CALL", 
+  3: "EMAIL",
+  4: "WHATSAPP",
+  5: "GMB",           // Google My Business
+  6: "FB",            // Facebook
+  7: "IG",            // Instagram
+  24: "LIVE_CHAT",
+  25: "ACTIVITY_CONTACT",      // Contact was created/updated
+  26: "ACTIVITY_INVOICE",      // Invoice activity
+  27: "ACTIVITY_OPPORTUNITY",  // Project/opportunity activity
+  28: "ACTIVITY_APPOINTMENT"   // Appointment activity
+};
+```
+
+## 🔄 Data Flow
+
+### 1. **Sending SMS from App**
+```
+User types message → POST /api/sms/send
+                    ↓
+                    → Create/update conversation (type: TYPE_PHONE)
+                    → Insert message (type: 1, conversationId: ObjectId)
+                    → Send to GHL API
+                    → Update conversation lastMessage fields
+```
+
+### 2. **Receiving Message via Webhook**
+```
+GHL sends webhook → POST /api/webhooks/ghl/native
+                   ↓
+                   → Queue in webhook_queue
+                   → MessagesProcessor picks it up
+                   → Find/create conversation
+                   → Insert message with conversationId as ObjectId
+                   → Update conversation metadata
+```
+
+### 3. **Loading Conversations in App**
+```
+App opens contact → GET /api/conversations?contactId=xxx
+                   ↓
+                   → Returns all conversations for contact
+                   → Shows last message preview
+                   → User taps conversation
+                   ↓
+                   GET /api/conversations/{id}/messages
+                   → Returns paginated messages
+                   → Marks messages as read
+                   → Updates unread count
+```
+
+## ⚠️ Critical Rules
+
+### 1. **conversationId MUST be ObjectId**
+```javascript
+// ❌ WRONG - Will break queries
+conversationId: "6856519a479e5bdcc186db5a"  // String
+
+// ✅ CORRECT
+conversationId: ObjectId("6856519a479e5bdcc186db5a")
+```
+
+### 2. **contactObjectId MUST be ObjectId**
+```javascript
+// ❌ WRONG - Old naming
+contactId: "6844d07b257a88ebfbd9be9b"  // String
+
+// ✅ CORRECT - New naming
+contactObjectId: ObjectId("6844d07b257a88ebfbd9be9b")
+```
+
+### 3. **Message type field is numeric**
+```javascript
+// ❌ WRONG
+type: "sms"
+
+// ✅ CORRECT  
+type: 1  // Numeric!
+```
+
+### 4. **Always filter by locationId**
+```javascript
+// Every query must include locationId for multi-tenant isolation
+db.messages.find({ 
+  conversationId: ObjectId("..."),
+  locationId: "5OuaTrizW5wkZMI1xtvX"  // REQUIRED
+})
+```
+
+## 🐛 Common Issues & Solutions
+
+### "No messages showing"
+1. Check conversationId is ObjectId in messages collection
+2. Verify message has `type: 1` (numeric) not `type: "sms"`
+3. Ensure `body` field exists on message
+4. Check locationId matches
+5. Verify contactObjectId points to correct contact
+
+### "Messages in wrong conversation"
+- Check if contactObjectId in conversation matches the messages
+- Verify conversationId is consistent across messages
+- Ensure GHL webhook processor is using correct field mapping
+
+### "Messages in wrong order"
+- Sort by `dateAdded` not `createdAt`
+- Frontend shows newest first (inverted FlatList)
+
+### "Unread count wrong"
+- Update conversation.unreadCount when marking messages read
+- Webhook processor sets `read: false` for inbound
+- Fetching messages marks them as read
+
+## 📝 Implementation Checklist
+
+When implementing messaging features:
+
+- [ ] Store conversationId as ObjectId, not string
+- [ ] Use contactObjectId (ObjectId) not contactId (string)
+- [ ] Include numeric type field (1 for SMS, 3 for Email)
+- [ ] Update conversation lastMessage fields
+- [ ] Handle unread counts properly
+- [ ] Always filter by locationId
+- [ ] Use proper field names (body not message)
+- [ ] Set read status appropriately
+- [ ] Include dateAdded timestamp
+- [ ] Store both ghlContactId and contactObjectId for reference
+
+## 🔧 Debugging Commands
+
+```javascript
+// Check conversation exists with new field
+db.conversations.findOne({ 
+  contactObjectId: ObjectId("6844d07b257a88ebfbd9be9b"),
+  locationId: "locationId",
+  type: "TYPE_PHONE" 
+})
+
+// Count messages with correct structure  
+db.messages.count({
+  conversationId: { $type: "objectId" },
+  contactObjectId: { $type: "objectId" },
+  type: { $type: "number" }
+})
+
+// Find conversations still using old contactId field
+db.conversations.find({
+  contactId: { $exists: true },
+  contactObjectId: { $exists: false }
+})
+
+// Migration: Convert contactId to contactObjectId
+db.conversations.find({ contactId: { $exists: true } }).forEach(function(doc) {
+  db.conversations.updateOne(
+    { _id: doc._id },
+    {
+      $set: { 
+        contactObjectId: ObjectId(doc.contactId),
+        ghlContactId: doc.ghlContactId || "" 
+      },
+      $unset: { contactId: "" }
+    }
+  );
+});
+
+// Fix messages with string contactId
+db.messages.find({ contactId: { $exists: true } }).forEach(function(doc) {
+  db.messages.updateOne(
+    { _id: doc._id },
+    {
+      $set: { 
+        contactObjectId: ObjectId(doc.contactId)
+      },
+      $unset: { contactId: "" }
+    }
+  );
+});
+```
+
+## 🚀 Future Improvements
+- Real-time updates via WebSocket
+- Message search functionality  
+- Conversation archiving
+- Message reactions
+- Read receipts
+- Typing indicators
+- Push notifications
+
+## 📋 Backend Updates Needed
+
+To fully implement the new naming convention:
+
+1. **Update `/api/sms/send`**:
+   - Use `contactObjectId` when creating conversations
+   - Store as ObjectId, not string
+
+2. **Update webhook processors**:
+   - `MessagesProcessor` should use `contactObjectId`
+   - Ensure ObjectId type consistency
+
+3. **Update API endpoints**:
+   - `/api/conversations` queries should use `contactObjectId`
+   - `/api/messages` should include `contactObjectId`
+
+4. **Add database indexes**:
+   ```javascript
+   db.conversations.createIndex({ contactObjectId: 1, locationId: 1 })
+   db.messages.createIndex({ contactObjectId: 1, conversationId: 1 })
+   ```
+
+   Searched project for “api conversations messages contactId endpoint”
+4 results
+
+
+
+
+
+
+
+
+Based on my search, here are all the files that need to be updated for the contactObjectId change:
+
+📝 Backend Files to Update
+1. API Endpoints
+/api/conversations/index.ts - Main conversations endpoint
+/api/conversations/[conversationId]/messages.ts - Messages endpoint
+/api/contacts/[contactId]/conversations.ts - Contact's conversations endpoint
+/api/sms/send.ts - SMS sending (creates conversations/messages)
+/api/emails/send.ts - Email sending (creates conversations/messages)
+2. Webhook Processors
+/utils/webhooks/processors/messages.ts - Processes message webhooks ⚡ CRITICAL
+/utils/webhooks/directProcessor.ts - Direct message processing
+3. Sync Functions
+/utils/sync/syncConversations.ts - Syncs conversations from GHL
+/utils/sync/syncMessages.ts - Syncs messages from GHL
+4. Other Backend Files
+/utils/reports/enhancedDailyReport.ts - May query conversations
+Any other files that query conversations/messages
+📱 Frontend Files to Update
+1. Services
+src/services/conversationService.ts - Main conversation service
+src/services/smsService.ts - SMS service (if it references contactId)
+2. Components
+src/components/ConversationsList.tsx - Displays conversations
+src/components/MessagesList.tsx - Displays messages (if exists)
+Any components that display conversation/message data
+3. Screens
+src/screens/ConversationScreen.tsx - Individual conversation view
+src/screens/ContactDetailsScreen.tsx - Shows contact's conversations
+Any other screens showing messages

--- a/lpai-backend/pages/api/contacts/batch.ts
+++ b/lpai-backend/pages/api/contacts/batch.ts
@@ -1,4 +1,6 @@
 // pages/api/contacts/batch.ts
+// Updated Date 06/24/2025
+
 import type { NextApiRequest, NextApiResponse } from 'next';
 import clientPromise from '../../../src/lib/mongodb';
 import { ObjectId } from 'mongodb';
@@ -384,10 +386,10 @@ async function processBatchOperation(db: any, body: any, res: NextApiResponse) {
           const duplicateObjectIds = duplicateIds.map((id: string) => new ObjectId(id));
           
           await Promise.all([
-            // Update projects
+            // Update projects - FIXED: Use contactObjectId
             db.collection('projects').updateMany(
-              { contactId: { $in: duplicateObjectIds } },
-              { $set: { contactId: new ObjectId(primaryId) } }
+              { contactObjectId: { $in: duplicateObjectIds } },
+              { $set: { contactObjectId: new ObjectId(primaryId) } }
             ),
             // Update appointments
             db.collection('appointments').updateMany(
@@ -399,10 +401,10 @@ async function processBatchOperation(db: any, body: any, res: NextApiResponse) {
               { contactId: { $in: duplicateObjectIds } },
               { $set: { contactId: new ObjectId(primaryId) } }
             ),
-            // Update conversations
+            // Update conversations - FIXED: Use contactObjectId
             db.collection('conversations').updateMany(
-              { contactId: { $in: duplicateObjectIds } },
-              { $set: { contactId: new ObjectId(primaryId) } }
+              { contactObjectId: { $in: duplicateObjectIds } },
+              { $set: { contactObjectId: new ObjectId(primaryId) } }
             )
           ]);
           

--- a/lpai-backend/src/utils/webhooks/processors/messages.ts
+++ b/lpai-backend/src/utils/webhooks/processors/messages.ts
@@ -1,5 +1,5 @@
 // src/utils/webhooks/processors/messages.ts
-// Date: 2025/06/23
+// Updated Date 06/24/2025
 // FIXED: Handle new webhook payload structure where conversation comes as { value: { _id: "..." } }
 // FIXED: Store conversationId as ObjectId, not string
 
@@ -11,807 +11,811 @@ import axios from 'axios';
 import { getAuthHeader } from '../../ghlAuth';
 
 export class MessagesProcessor extends BaseProcessor {
-  constructor(db?: Db) {
-    super({
-      queueType: 'messages',
-      batchSize: 50,
-      maxRuntime: 50000,
-      processorName: 'MessagesProcessor'
-    }, db);
-  }
+ constructor(db?: Db) {
+   super({
+     queueType: 'messages',
+     batchSize: 50,
+     maxRuntime: 50000,
+     processorName: 'MessagesProcessor'
+   }, db);
+ }
 
-  /**
-   * Process message webhooks
-   */
-  protected async processItem(item: QueueItem): Promise<void> {
-    const { type, payload, webhookId } = item;
+ /**
+  * Process message webhooks
+  */
+ protected async processItem(item: QueueItem): Promise<void> {
+   const { type, payload, webhookId } = item;
 
-    // Track message processing start
-    const messageStartTime = Date.now();
+   // Track message processing start
+   const messageStartTime = Date.now();
 
-    switch (type) {
-      case 'InboundMessage':
-        await this.processInboundMessage(payload, webhookId);
-        break;
-        
-      case 'OutboundMessage':
-        await this.processOutboundMessage(payload, webhookId);
-        break;
-        
-      case 'ConversationUnreadUpdate':
-        await this.processConversationUpdate(payload, webhookId);
-        break;
-        
-      case 'LCEmailStats':
-        await this.processLCEmailStats(payload, webhookId);
-        break;
-        
-      default:
-        console.warn(`[MessagesProcessor] Unknown message type: ${type}`);
-        throw new Error(`Unsupported message webhook type: ${type}`);
-    }
+   switch (type) {
+     case 'InboundMessage':
+       await this.processInboundMessage(payload, webhookId);
+       break;
+       
+     case 'OutboundMessage':
+       await this.processOutboundMessage(payload, webhookId);
+       break;
+       
+     case 'ConversationUnreadUpdate':
+       await this.processConversationUpdate(payload, webhookId);
+       break;
+       
+     case 'LCEmailStats':
+       await this.processLCEmailStats(payload, webhookId);
+       break;
+       
+     default:
+       console.warn(`[MessagesProcessor] Unknown message type: ${type}`);
+       throw new Error(`Unsupported message webhook type: ${type}`);
+   }
 
-    // Track message processing time
-    const processingTime = Date.now() - messageStartTime;
-    if (processingTime > 2000) {
-      console.warn(`[MessagesProcessor] Slow message processing: ${processingTime}ms for ${type}`);
-    }
-  }
+   // Track message processing time
+   const processingTime = Date.now() - messageStartTime;
+   if (processingTime > 2000) {
+     console.warn(`[MessagesProcessor] Slow message processing: ${processingTime}ms for ${type}`);
+   }
+ }
 
-  /**
-   * Process inbound message (SMS/Email/WhatsApp)
-   */
-  private async processInboundMessage(payload: any, webhookId: string): Promise<void> {
-    // Handle the nested structure - check if this is a native webhook format
-    let locationId, contactId, conversationId, message, timestamp, conversation;
-    
-    if (payload.webhookPayload) {
-      // Native webhook format - extract from webhookPayload
-      const webhookData = payload.webhookPayload;
-      locationId = payload.locationId || webhookData.locationId;
-      contactId = webhookData.contactId;
-      conversationId = webhookData.conversationId;
-      message = webhookData.message;
-      timestamp = webhookData.timestamp || payload.timestamp;
-      // NEW: Handle new conversation structure
-      conversation = webhookData.conversation;
-    } else {
-      // Direct format - handle the actual webhook structure we're receiving
-      locationId = payload.locationId;
-      contactId = payload.contactId;
-      conversationId = payload.conversationId;
-      timestamp = payload.timestamp;
-      conversation = payload.conversation;
-      
-      // Handle message structure - GHL sends body/messageType directly
-      if (payload.body) {
-        message = {
-          id: payload.messageId,
-          body: payload.body,
-          type: payload.messageType === 'SMS' ? 1 : (payload.messageType === 'Email' ? 3 : 1),
-          messageType: payload.messageType,
-          status: payload.status,
-          dateAdded: payload.dateAdded,
-          meta: payload.meta || {}
-        };
-      } else {
-        message = payload.message;
-      }
-    }
-    
-    if (!locationId || !contactId || !message) {
-      console.error(`[MessagesProcessor] Missing required fields for inbound message:`, {
-        locationId: !!locationId,
-        contactId: !!contactId,
-        message: !!message,
-        webhookId
-      });
-      return;
-    }
+ /**
+  * Process inbound message (SMS/Email/WhatsApp)
+  */
+ private async processInboundMessage(payload: any, webhookId: string): Promise<void> {
+   // Handle the nested structure - check if this is a native webhook format
+   let locationId, contactId, conversationId, message, timestamp, conversation;
+   
+   if (payload.webhookPayload) {
+     // Native webhook format - extract from webhookPayload
+     const webhookData = payload.webhookPayload;
+     locationId = payload.locationId || webhookData.locationId;
+     contactId = webhookData.contactId;
+     conversationId = webhookData.conversationId;
+     message = webhookData.message;
+     timestamp = webhookData.timestamp || payload.timestamp;
+     // NEW: Handle new conversation structure
+     conversation = webhookData.conversation;
+   } else {
+     // Direct format - handle the actual webhook structure we're receiving
+     locationId = payload.locationId;
+     contactId = payload.contactId;
+     conversationId = payload.conversationId;
+     timestamp = payload.timestamp;
+     conversation = payload.conversation;
+     
+     // Handle message structure - GHL sends body/messageType directly
+     if (payload.body) {
+       message = {
+         id: payload.messageId,
+         body: payload.body,
+         type: payload.messageType === 'SMS' ? 1 : (payload.messageType === 'Email' ? 3 : 1),
+         messageType: payload.messageType,
+         status: payload.status,
+         dateAdded: payload.dateAdded,
+         meta: payload.meta || {}
+       };
+     } else {
+       message = payload.message;
+     }
+   }
+   
+   if (!locationId || !contactId || !message) {
+     console.error(`[MessagesProcessor] Missing required fields for inbound message:`, {
+       locationId: !!locationId,
+       contactId: !!contactId,
+       message: !!message,
+       webhookId
+     });
+     return;
+   }
 
-    // Find or create contact
-    let contact = await this.db.collection('contacts').findOne(
-      { ghlContactId: contactId, locationId },
-      { 
-        projection: { 
-          _id: 1, 
-          firstName: 1, 
-          lastName: 1, 
-          email: 1, 
-          phone: 1,
-          fullName: 1,
-          dateAdded: 1
-        } 
-      }
-    );
-    
-    if (!contact) {
-      // Create new contact record
-      const fullName = `${message.contactFirstName || ''} ${message.contactLastName || ''}`.trim() || 'Unknown';
-      
-      contact = {
-        _id: new ObjectId(),
-        ghlContactId: contactId,
-        locationId,
-        firstName: message.contactFirstName || '',
-        lastName: message.contactLastName || '',
-        fullName,
-        email: message.contactEmail || '',
-        phone: message.contactPhone || '',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        createdByWebhook: webhookId,
-        lastActivity: new Date()
-      };
-      
-      await this.db.collection('contacts').insertOne(contact);
-      console.log(`[MessagesProcessor] Created new contact: ${contact._id} (${fullName})`);
-    }
+   // Find or create contact
+   let contact = await this.db.collection('contacts').findOne(
+     { ghlContactId: contactId, locationId },
+     { 
+       projection: { 
+         _id: 1, 
+         firstName: 1, 
+         lastName: 1, 
+         email: 1, 
+         phone: 1,
+         fullName: 1,
+         dateAdded: 1
+       } 
+     }
+   );
+   
+   if (!contact) {
+     // Create new contact record
+     const fullName = `${message.contactFirstName || ''} ${message.contactLastName || ''}`.trim() || 'Unknown';
+     
+     contact = {
+       _id: new ObjectId(),
+       ghlContactId: contactId,
+       locationId,
+       firstName: message.contactFirstName || '',
+       lastName: message.contactLastName || '',
+       fullName,
+       email: message.contactEmail || '',
+       phone: message.contactPhone || '',
+       createdAt: new Date(),
+       updatedAt: new Date(),
+       createdByWebhook: webhookId,
+       lastActivity: new Date()
+     };
+     
+     await this.db.collection('contacts').insertOne(contact);
+     console.log(`[MessagesProcessor] Created new contact: ${contact._id} (${fullName})`);
+   }
 
-    // Get conversation type from message
-    const conversationType = this.getConversationType(message.type);
-    
-    // Start a session for atomic operations
-    const session = this.db.client.startSession();
-    
-    try {
-      await session.withTransaction(async () => {
-        // Update or create conversation
-        const conversationResult = await this.db.collection('conversations').findOneAndUpdate(
-          { 
-            ghlConversationId: conversationId,
-            locationId 
-          },
-          {
-            $set: {
-              ghlConversationId: conversationId,
-              locationId,
-              contactId: contact._id.toString(),
-              type: conversationType,
-              lastMessageDate: new Date(),
-              lastMessageBody: message.body?.substring(0, 200) || '',
-              lastMessageType: this.getMessageTypeName(message.type),
-              lastMessageDirection: 'inbound',
-              contactName: contact.fullName || `${contact.firstName || ''} ${contact.lastName || ''}`.trim(),
-              contactEmail: contact.email,
-              contactPhone: contact.phone,
-              updatedAt: new Date()
-            },
-            $inc: { unreadCount: 1 },
-            $setOnInsert: {
-              _id: new ObjectId(),
-              createdAt: new Date(),
-              inbox: true,
-              starred: false,
-              scoring: [],
-              followers: [],
-              tags: [],
-              dateAdded: new Date(message.dateAdded || timestamp || Date.now()),
-              attributed: false,
-              dateUpdated: new Date(),
-              lastSyncedAt: new Date(),
-              createdBySync: false,
-              createdByWebhook: webhookId
-            }
-          },
-          { 
-            upsert: true,
-            returnDocument: 'after',
-            session 
-          }
-        );
+   // Get conversation type from message
+   const conversationType = this.getConversationType(message.type);
+   
+   // Start a session for atomic operations
+   const session = this.db.client.startSession();
+   
+   try {
+     await session.withTransaction(async () => {
+       // Update or create conversation
+       const conversationResult = await this.db.collection('conversations').findOneAndUpdate(
+         { 
+           ghlConversationId: conversationId,
+           locationId 
+         },
+         {
+           $set: {
+             ghlConversationId: conversationId,
+             locationId,
+             contactObjectId: contact._id,  // Store as ObjectId, not string
+             ghlContactId: contactId,        // Keep GHL ID for reference
+             type: conversationType,
+             lastMessageDate: new Date(),
+             lastMessageBody: message.body?.substring(0, 200) || '',
+             lastMessageType: this.getMessageTypeName(message.type),
+             lastMessageDirection: 'inbound',
+             contactName: contact.fullName || `${contact.firstName || ''} ${contact.lastName || ''}`.trim(),
+             contactEmail: contact.email,
+             contactPhone: contact.phone,
+             updatedAt: new Date()
+           },
+           $inc: { unreadCount: 1 },
+           $setOnInsert: {
+             _id: new ObjectId(),
+             createdAt: new Date(),
+             inbox: true,
+             starred: false,
+             scoring: [],
+             followers: [],
+             tags: [],
+             dateAdded: new Date(message.dateAdded || timestamp || Date.now()),
+             attributed: false,
+             dateUpdated: new Date(),
+             lastSyncedAt: new Date(),
+             createdBySync: false,
+             createdByWebhook: webhookId
+           }
+         },
+         { 
+           upsert: true,
+           returnDocument: 'after',
+           session 
+         }
+       );
 
-        // FIXED: Handle new webhook payload structure
-        let conversationObjectId;
-        if (conversation && conversation.value && conversation.value._id) {
-          // New webhook format: conversation comes as { value: { _id: "..." } }
-          conversationObjectId = new ObjectId(conversation.value._id);
-          console.log(`[MessagesProcessor] Using conversation._id from new webhook format: ${conversation.value._id}`);
-        } else if (conversationResult && conversationResult.value && conversationResult.value._id) {
-          // Standard format from findOneAndUpdate
-          conversationObjectId = conversationResult.value._id;
-        } else if (conversationResult && conversationResult._id) {
-          // Sometimes the result comes without .value wrapper
-          conversationObjectId = conversationResult._id;
-        } else {
-          console.error(`[MessagesProcessor] Could not determine conversation ObjectId`, {
-            hasConversation: !!conversation,
-            hasConversationValue: !!(conversation && conversation.value),
-            hasConversationValueId: !!(conversation && conversation.value && conversation.value._id),
-            hasResult: !!conversationResult,
-            hasResultValue: !!(conversationResult && conversationResult.value),
-            conversationResultKeys: conversationResult ? Object.keys(conversationResult) : [],
-            ghlConversationId: conversationId
-          });
-          // As a last resort, look up the conversation by ghlConversationId
-          const existingConversation = await this.db.collection('conversations').findOne({
-            ghlConversationId: conversationId,
-            locationId
-          });
-          if (existingConversation && existingConversation._id) {
-            conversationObjectId = existingConversation._id;
-            console.log(`[MessagesProcessor] Found conversation by ghlConversationId lookup: ${conversationObjectId}`);
-          } else {
-            throw new Error('Could not determine conversation ObjectId');
-          }
-        }
+       // FIXED: Handle new webhook payload structure
+       let conversationObjectId;
+       if (conversation && conversation.value && conversation.value._id) {
+         // New webhook format: conversation comes as { value: { _id: "..." } }
+         conversationObjectId = new ObjectId(conversation.value._id);
+         console.log(`[MessagesProcessor] Using conversation._id from new webhook format: ${conversation.value._id}`);
+       } else if (conversationResult && conversationResult.value && conversationResult.value._id) {
+         // Standard format from findOneAndUpdate
+         conversationObjectId = conversationResult.value._id;
+       } else if (conversationResult && conversationResult._id) {
+         // Sometimes the result comes without .value wrapper
+         conversationObjectId = conversationResult._id;
+       } else {
+         console.error(`[MessagesProcessor] Could not determine conversation ObjectId`, {
+           hasConversation: !!conversation,
+           hasConversationValue: !!(conversation && conversation.value),
+           hasConversationValueId: !!(conversation && conversation.value && conversation.value._id),
+           hasResult: !!conversationResult,
+           hasResultValue: !!(conversationResult && conversationResult.value),
+           conversationResultKeys: conversationResult ? Object.keys(conversationResult) : [],
+           ghlConversationId: conversationId
+         });
+         // As a last resort, look up the conversation by ghlConversationId
+         const existingConversation = await this.db.collection('conversations').findOne({
+           ghlConversationId: conversationId,
+           locationId
+         });
+         if (existingConversation && existingConversation._id) {
+           conversationObjectId = existingConversation._id;
+           console.log(`[MessagesProcessor] Found conversation by ghlConversationId lookup: ${conversationObjectId}`);
+         } else {
+           throw new Error('Could not determine conversation ObjectId');
+         }
+       }
 
-        // Build message document
-        const messageDoc: any = {
-          _id: new ObjectId(),
-          ghlMessageId: message?.id || new ObjectId().toString(),
-          conversationId: conversationObjectId, // Use ObjectId directly
-          ghlConversationId: conversationId,
-          locationId,
-          contactId: contact._id.toString(),
-          senderId: contact._id.toString(),
-          type: message?.type || 1,
-          messageType: message?.messageType || 'TYPE_PHONE',
-          direction: 'inbound',
-          dateAdded: new Date(message?.dateAdded || timestamp || Date.now()),
-          read: false,
-          createdAt: new Date(),
-          processedBy: 'queue',
-          webhookId
-        };
+       // Build message document
+       const messageDoc: any = {
+         _id: new ObjectId(),
+         ghlMessageId: message?.id || new ObjectId().toString(),
+         conversationId: conversationObjectId, // Use ObjectId directly
+         ghlConversationId: conversationId,
+         locationId,
+         contactObjectId: contact._id,  // Store as ObjectId
+         ghlContactId: contactId,        // Keep GHL ID
+         senderId: contact._id.toString(),
+         type: message?.type || 1,
+         messageType: message?.messageType || 'TYPE_PHONE',
+         direction: 'inbound',
+         dateAdded: new Date(message?.dateAdded || timestamp || Date.now()),
+         read: false,
+         createdAt: new Date(),
+         processedBy: 'queue',
+         webhookId
+       };
 
-        // Handle different message types
-        switch (message.type) {
-          case 1: // SMS
-            messageDoc.body = message.body || '';
-            messageDoc.status = message.status || 'received';
-            messageDoc.segments = message.segments || 1;
-            break;
-            
-          case 3: // Email
-            // Store email reference for lazy loading
-            if (message.meta?.email?.messageIds?.[0]) {
-              messageDoc.emailMessageId = message.meta.email.messageIds[0];
-              messageDoc.needsContentFetch = true;
-              messageDoc.subject = message.subject || 'No subject';
-              
-              // NEW: AUTO-FETCH EMAIL CONTENT
-              try {
-                const emailContent = await this.fetchEmailContent(
-                  message.meta.email.messageIds[0], 
-                  locationId
-                );
-                
-                if (emailContent) {
-                  messageDoc.body = emailContent.body;
-                  messageDoc.htmlBody = emailContent.htmlBody;
-                  messageDoc.subject = emailContent.subject;
-                  messageDoc.needsContentFetch = false;
-                  messageDoc.emailFetchedAt = new Date();
-                  console.log(`[MessagesProcessor] Email content auto-fetched for ${message.meta.email.messageIds[0]}`);
-                }
-              } catch (fetchError) {
-                console.error(`[MessagesProcessor] Failed to auto-fetch email content:`, fetchError);
-                // Continue processing - email can be fetched later
-              }
-            } else {
-              messageDoc.subject = message.subject || 'No subject';
-              messageDoc.body = message.body || '';
-              messageDoc.htmlBody = message.htmlBody;
-            }
-            break;
-            
-          case 4: // WhatsApp
-            messageDoc.body = message.body || '';
-            messageDoc.mediaUrl = message.mediaUrl;
-            messageDoc.mediaType = message.mediaType;
-            break;
-            
-          default:
-            messageDoc.body = message.body || '';
-            messageDoc.meta = message.meta || {};
-        }
+       // Handle different message types
+       switch (message.type) {
+         case 1: // SMS
+           messageDoc.body = message.body || '';
+           messageDoc.status = message.status || 'received';
+           messageDoc.segments = message.segments || 1;
+           break;
+           
+         case 3: // Email
+           // Store email reference for lazy loading
+           if (message.meta?.email?.messageIds?.[0]) {
+             messageDoc.emailMessageId = message.meta.email.messageIds[0];
+             messageDoc.needsContentFetch = true;
+             messageDoc.subject = message.subject || 'No subject';
+             
+             // NEW: AUTO-FETCH EMAIL CONTENT
+             try {
+               const emailContent = await this.fetchEmailContent(
+                 message.meta.email.messageIds[0], 
+                 locationId
+               );
+               
+               if (emailContent) {
+                 messageDoc.body = emailContent.body;
+                 messageDoc.htmlBody = emailContent.htmlBody;
+                 messageDoc.subject = emailContent.subject;
+                 messageDoc.needsContentFetch = false;
+                 messageDoc.emailFetchedAt = new Date();
+                 console.log(`[MessagesProcessor] Email content auto-fetched for ${message.meta.email.messageIds[0]}`);
+               }
+             } catch (fetchError) {
+               console.error(`[MessagesProcessor] Failed to auto-fetch email content:`, fetchError);
+               // Continue processing - email can be fetched later
+             }
+           } else {
+             messageDoc.subject = message.subject || 'No subject';
+             messageDoc.body = message.body || '';
+             messageDoc.htmlBody = message.htmlBody;
+           }
+           break;
+           
+         case 4: // WhatsApp
+           messageDoc.body = message.body || '';
+           messageDoc.mediaUrl = message.mediaUrl;
+           messageDoc.mediaType = message.mediaType;
+           break;
+           
+         default:
+           messageDoc.body = message.body || '';
+           messageDoc.meta = message.meta || {};
+       }
 
-        // Insert message
-        await this.db.collection('messages').insertOne(messageDoc, { session });
+       // Insert message
+       await this.db.collection('messages').insertOne(messageDoc, { session });
 
-        // Check for active project (optimized)
-        const project = await this.db.collection('projects').findOne(
-          {
-            contactId: contact._id.toString(),
-            locationId,
-            status: { $in: ['open', 'quoted', 'won', 'in_progress'] }
-          },
-          { 
-            projection: { _id: 1 },
-            session 
-          }
-        );
+       // Check for active project (optimized)
+       const project = await this.db.collection('projects').findOne(
+         {
+           contactObjectId: contact._id,  // Use contactObjectId for consistency
+           locationId,
+           status: { $in: ['open', 'quoted', 'won', 'in_progress'] }
+         },
+         { 
+           projection: { _id: 1 },
+           session 
+         }
+       );
 
-        if (project) {
-          messageDoc.projectId = project._id.toString();
-          await this.db.collection('messages').updateOne(
-            { _id: messageDoc._id },
-            { $set: { projectId: project._id.toString() } },
-            { session }
-          );
-        }
-      });
+       if (project) {
+         messageDoc.projectId = project._id.toString();
+         await this.db.collection('messages').updateOne(
+           { _id: messageDoc._id },
+           { $set: { projectId: project._id.toString() } },
+           { session }
+         );
+       }
+     });
 
-      // TODO: Trigger push notifications (outside transaction)
-      // await this.sendPushNotifications(contact, message);
-      
-    } finally {
-      await session.endSession();
-    }
-  }
+     // TODO: Trigger push notifications (outside transaction)
+     // await this.sendPushNotifications(contact, message);
+     
+   } finally {
+     await session.endSession();
+   }
+ }
 
-  /**
-   * Process outbound message
-   */
-  private async processOutboundMessage(payload: any, webhookId: string): Promise<void> {
-    // Handle the nested structure
-    let locationId, contactId, conversationId, message, userId, timestamp, conversation;
-    
-    if (payload.webhookPayload) {
-      // Native webhook format
-      const webhookData = payload.webhookPayload;
-      locationId = payload.locationId || webhookData.locationId;
-      contactId = webhookData.contactId;
-      conversationId = webhookData.conversationId;
-      message = webhookData;  // For outbound, the whole webhookPayload is the message
-      userId = webhookData.userId;
-      timestamp = webhookData.timestamp || payload.timestamp;
-      // NEW: Handle new conversation structure
-      conversation = webhookData.conversation;
-      
-      // Extract message details from webhookData
-      if (!message.body && webhookData.body) {
-        message = {
-          body: webhookData.body,
-          type: webhookData.direction === 'outbound' ? 1 : 3, // Default to SMS
-          messageType: webhookData.messageType,
-          dateAdded: webhookData.dateAdded
-        };
-      }
-    } else {
-      // Direct format - handle the actual webhook structure
-      locationId = payload.locationId;
-      contactId = payload.contactId;
-      conversationId = payload.conversationId;
-      userId = payload.userId;
-      timestamp = payload.timestamp;
-      conversation = payload.conversation;
-      
-      // Handle message structure for outbound
-      if (payload.body) {
-        message = {
-          id: payload.messageId,
-          body: payload.body,
-          type: payload.messageType === 'SMS' ? 1 : (payload.messageType === 'Email' ? 3 : 1),
-          messageType: payload.messageType,
-          status: payload.status,
-          dateAdded: payload.dateAdded,
-          meta: payload.meta || {}
-        };
-      } else {
-        message = payload.message;
-      }
-    }
-    
-    // Add validation for required fields
-    if (!locationId || !contactId) {
-      console.warn(`[MessagesProcessor] Missing required fields for outbound message:`, {
-        locationId: !!locationId,
-        contactId: !!contactId,
-        webhookId
-      });
-      return; // Skip processing if fields are missing
-    }
+ /**
+  * Process outbound message
+  */
+ private async processOutboundMessage(payload: any, webhookId: string): Promise<void> {
+   // Handle the nested structure
+   let locationId, contactId, conversationId, message, userId, timestamp, conversation;
+   
+   if (payload.webhookPayload) {
+     // Native webhook format
+     const webhookData = payload.webhookPayload;
+     locationId = payload.locationId || webhookData.locationId;
+     contactId = webhookData.contactId;
+     conversationId = webhookData.conversationId;
+     message = webhookData;  // For outbound, the whole webhookPayload is the message
+     userId = webhookData.userId;
+     timestamp = webhookData.timestamp || payload.timestamp;
+     // NEW: Handle new conversation structure
+     conversation = webhookData.conversation;
+     
+     // Extract message details from webhookData
+     if (!message.body && webhookData.body) {
+       message = {
+         body: webhookData.body,
+         type: webhookData.direction === 'outbound' ? 1 : 3, // Default to SMS
+         messageType: webhookData.messageType,
+         dateAdded: webhookData.dateAdded
+       };
+     }
+   } else {
+     // Direct format - handle the actual webhook structure
+     locationId = payload.locationId;
+     contactId = payload.contactId;
+     conversationId = payload.conversationId;
+     userId = payload.userId;
+     timestamp = payload.timestamp;
+     conversation = payload.conversation;
+     
+     // Handle message structure for outbound
+     if (payload.body) {
+       message = {
+         id: payload.messageId,
+         body: payload.body,
+         type: payload.messageType === 'SMS' ? 1 : (payload.messageType === 'Email' ? 3 : 1),
+         messageType: payload.messageType,
+         status: payload.status,
+         dateAdded: payload.dateAdded,
+         meta: payload.meta || {}
+       };
+     } else {
+       message = payload.message;
+     }
+   }
+   
+   // Add validation for required fields
+   if (!locationId || !contactId) {
+     console.warn(`[MessagesProcessor] Missing required fields for outbound message:`, {
+       locationId: !!locationId,
+       contactId: !!contactId,
+       webhookId
+     });
+     return; // Skip processing if fields are missing
+   }
 
-    // Find contact
-    let contact = await this.db.collection('contacts').findOne(
-      { ghlContactId: contactId, locationId },
-      { 
-        projection: { 
-          _id: 1, 
-          firstName: 1, 
-          lastName: 1, 
-          email: 1, 
-          phone: 1,
-          fullName: 1
-        } 
-      }
-    );
-    
-    if (!contact) {
-      console.warn(`[MessagesProcessor] Contact not found for outbound message: ${contactId}, creating minimal contact`);
-      
-      // Create a minimal contact record
-      const newContact = {
-        _id: new ObjectId(),
-        ghlContactId: contactId,
-        locationId,
-        firstName: '',
-        lastName: '',
-        fullName: 'Unknown Contact',
-        email: '',
-        phone: '',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        createdByWebhook: webhookId,
-        needsSync: true // Flag for later sync
-      };
-      
-      try {
-        await this.db.collection('contacts').insertOne(newContact);
-        console.log(`[MessagesProcessor] Created minimal contact for outbound message: ${contactId}`);
-        contact = newContact;
-      } catch (insertError: any) {
-        // Handle duplicate key error - contact might have been created by another process
-        if (insertError.code === 11000) {
-          // Try to find the contact again
-          contact = await this.db.collection('contacts').findOne(
-            { ghlContactId: contactId, locationId },
-            { projection: { _id: 1, firstName: 1, lastName: 1, email: 1, phone: 1, fullName: 1 } }
-          );
-          
-          if (!contact) {
-            console.error(`[MessagesProcessor] Failed to create or find contact for outbound message: ${contactId}`);
-            return;
-          }
-        } else {
-          console.error(`[MessagesProcessor] Failed to create contact for outbound message:`, insertError);
-          return;
-        }
-      }
-    }
+   // Find contact
+   let contact = await this.db.collection('contacts').findOne(
+     { ghlContactId: contactId, locationId },
+     { 
+       projection: { 
+         _id: 1, 
+         firstName: 1, 
+         lastName: 1, 
+         email: 1, 
+         phone: 1,
+         fullName: 1
+       } 
+     }
+   );
+   
+   if (!contact) {
+     console.warn(`[MessagesProcessor] Contact not found for outbound message: ${contactId}, creating minimal contact`);
+     
+     // Create a minimal contact record
+     const newContact = {
+       _id: new ObjectId(),
+       ghlContactId: contactId,
+       locationId,
+       firstName: '',
+       lastName: '',
+       fullName: 'Unknown Contact',
+       email: '',
+       phone: '',
+       createdAt: new Date(),
+       updatedAt: new Date(),
+       createdByWebhook: webhookId,
+       needsSync: true // Flag for later sync
+     };
+     
+     try {
+       await this.db.collection('contacts').insertOne(newContact);
+       console.log(`[MessagesProcessor] Created minimal contact for outbound message: ${contactId}`);
+       contact = newContact;
+     } catch (insertError: any) {
+       // Handle duplicate key error - contact might have been created by another process
+       if (insertError.code === 11000) {
+         // Try to find the contact again
+         contact = await this.db.collection('contacts').findOne(
+           { ghlContactId: contactId, locationId },
+           { projection: { _id: 1, firstName: 1, lastName: 1, email: 1, phone: 1, fullName: 1 } }
+         );
+         
+         if (!contact) {
+           console.error(`[MessagesProcessor] Failed to create or find contact for outbound message: ${contactId}`);
+           return;
+         }
+       } else {
+         console.error(`[MessagesProcessor] Failed to create contact for outbound message:`, insertError);
+         return;
+       }
+     }
+   }
 
-    // Find user who sent it
-    let senderId = null;
-    if (userId) {
-      const user = await this.db.collection('users').findOne(
-        { ghlUserId: userId, locationId },
-        { projection: { _id: 1 } }
-      );
-      if (user) {
-        senderId = user._id.toString();
-      }
-    }
+   // Find user who sent it
+   let senderId = null;
+   if (userId) {
+     const user = await this.db.collection('users').findOne(
+       { ghlUserId: userId, locationId },
+       { projection: { _id: 1 } }
+     );
+     if (user) {
+       senderId = user._id.toString();
+     }
+   }
 
-    const conversationType = message?.type ? this.getConversationType(message.type) : 'TYPE_PHONE';
+   const conversationType = message?.type ? this.getConversationType(message.type) : 'TYPE_PHONE';
 
-    // Update or create conversation
-    const conversationResult = await this.db.collection('conversations').findOneAndUpdate(
-      { 
-        ghlConversationId: conversationId,
-        locationId 
-      },
-      {
-        $set: {
-          ghlConversationId: conversationId,
-          locationId,
-          contactId: contact._id.toString(),
-          type: conversationType,
-          lastMessageDate: new Date(),
-          lastMessageBody: message?.body?.substring(0, 200) || '',
-          lastMessageType: message?.messageType || 'TYPE_PHONE',
-          lastMessageDirection: 'outbound',
-          contactName: contact.fullName || `${contact.firstName || ''} ${contact.lastName || ''}`.trim() || 'Unknown',
-          contactEmail: contact.email,
-          contactPhone: contact.phone,
-          updatedAt: new Date()
-        },
-        $setOnInsert: {
-          _id: new ObjectId(),
-          createdAt: new Date(),
-          inbox: true,
-          starred: false,
-          scoring: [],
-          followers: [],
-          tags: [],
-          unreadCount: 0,
-          dateAdded: new Date(),
-          attributed: false,
-          dateUpdated: new Date(),
-          lastSyncedAt: new Date(),
-          createdBySync: false,
-          createdByWebhook: webhookId
-        }
-      },
-      { 
-        upsert: true,
-        returnDocument: 'after'
-      }
-    );
+   // Update or create conversation
+   const conversationResult = await this.db.collection('conversations').findOneAndUpdate(
+     { 
+       ghlConversationId: conversationId,
+       locationId 
+     },
+     {
+       $set: {
+         ghlConversationId: conversationId,
+         locationId,
+         contactObjectId: contact._id,  // FIXED: Use contactObjectId as ObjectId
+         ghlContactId: contactId,        // FIXED: Add GHL contact ID
+         type: conversationType,
+         lastMessageDate: new Date(),
+         lastMessageBody: message?.body?.substring(0, 200) || '',
+         lastMessageType: message?.messageType || 'TYPE_PHONE',
+         lastMessageDirection: 'outbound',
+         contactName: contact.fullName || `${contact.firstName || ''} ${contact.lastName || ''}`.trim() || 'Unknown',
+         contactEmail: contact.email,
+         contactPhone: contact.phone,
+         updatedAt: new Date()
+       },
+       $setOnInsert: {
+         _id: new ObjectId(),
+         createdAt: new Date(),
+         inbox: true,
+         starred: false,
+         scoring: [],
+         followers: [],
+         tags: [],
+         unreadCount: 0,
+         dateAdded: new Date(),
+         attributed: false,
+         dateUpdated: new Date(),
+         lastSyncedAt: new Date(),
+         createdBySync: false,
+         createdByWebhook: webhookId
+       }
+     },
+     { 
+       upsert: true,
+       returnDocument: 'after'
+     }
+   );
 
-    // FIXED: Handle new webhook payload structure for outbound too
-    let conversationObjectId;
-    if (conversation && conversation.value && conversation.value._id) {
-      // New webhook format: conversation comes as { value: { _id: "..." } }
-      conversationObjectId = new ObjectId(conversation.value._id);
-      console.log(`[MessagesProcessor] Using conversation._id from new webhook format (outbound): ${conversation.value._id}`);
-    } else if (conversationResult && conversationResult.value && conversationResult.value._id) {
-      // Standard format from findOneAndUpdate
-      conversationObjectId = conversationResult.value._id;
-    } else {
-      console.error(`[MessagesProcessor] Could not determine conversation ObjectId for outbound`, {
-        hasConversation: !!conversation,
-        hasResult: !!conversationResult
-      });
-      throw new Error('Could not determine conversation ObjectId for outbound message');
-    }
+   // FIXED: Handle new webhook payload structure for outbound too
+   let conversationObjectId;
+   if (conversation && conversation.value && conversation.value._id) {
+     // New webhook format: conversation comes as { value: { _id: "..." } }
+     conversationObjectId = new ObjectId(conversation.value._id);
+     console.log(`[MessagesProcessor] Using conversation._id from new webhook format (outbound): ${conversation.value._id}`);
+   } else if (conversationResult && conversationResult.value && conversationResult.value._id) {
+     // Standard format from findOneAndUpdate
+     conversationObjectId = conversationResult.value._id;
+   } else {
+     console.error(`[MessagesProcessor] Could not determine conversation ObjectId for outbound`, {
+       hasConversation: !!conversation,
+       hasResult: !!conversationResult
+     });
+     throw new Error('Could not determine conversation ObjectId for outbound message');
+   }
 
-    // Build message document
-    const messageDoc: any = {
-      _id: new ObjectId(),
-      ghlMessageId: message?.id || new ObjectId().toString(),
-      conversationId: conversationObjectId, // Use ObjectId directly
-      ghlConversationId: conversationId,
-      locationId,
-      contactId: contact._id.toString(),
-      senderId,
-      type: message?.type || 1,
-      messageType: message?.messageType || 'TYPE_PHONE',
-      direction: 'outbound',
-      dateAdded: new Date(message?.dateAdded || timestamp || Date.now()),
-      read: true,
-      createdAt: new Date(),
-      processedBy: 'queue',
-      webhookId
-    };
+   // Build message document
+   const messageDoc: any = {
+     _id: new ObjectId(),
+     ghlMessageId: message?.id || new ObjectId().toString(),
+     conversationId: conversationObjectId, // Use ObjectId directly
+     ghlConversationId: conversationId,
+     locationId,
+     contactObjectId: contact._id,  // FIXED: Use contactObjectId as ObjectId
+     ghlContactId: contactId,        // FIXED: Add GHL contact ID
+     senderId,
+     type: message?.type || 1,
+     messageType: message?.messageType || 'TYPE_PHONE',
+     direction: 'outbound',
+     dateAdded: new Date(message?.dateAdded || timestamp || Date.now()),
+     read: true,
+     createdAt: new Date(),
+     processedBy: 'queue',
+     webhookId
+   };
 
-    // Handle different message types
-    if (message) {
-      switch (message.type) {
-        case 1: // SMS
-          messageDoc.body = message.body || '';
-          messageDoc.status = message.status || 'sent';
-          messageDoc.segments = message.segments || 1;
-          break;
-          
-        case 3: // Email
-          messageDoc.subject = message.subject || 'No subject';
-          
-          // Check if we have email message ID for content fetch
-          if (message.meta?.email?.messageIds?.[0]) {
-            messageDoc.emailMessageId = message.meta.email.messageIds[0];
-            messageDoc.needsContentFetch = true;
-            
-            // NEW: AUTO-FETCH EMAIL CONTENT FOR OUTBOUND
-            try {
-              const emailContent = await this.fetchEmailContent(
-                message.meta.email.messageIds[0], 
-                locationId
-              );
-              
-              if (emailContent) {
-                messageDoc.body = emailContent.body;
-                messageDoc.htmlBody = emailContent.htmlBody;
-                messageDoc.subject = emailContent.subject;
-                messageDoc.needsContentFetch = false;
-                messageDoc.emailFetchedAt = new Date();
-                console.log(`[MessagesProcessor] Outbound email content auto-fetched for ${message.meta.email.messageIds[0]}`);
-              }
-            } catch (fetchError) {
-              console.error(`[MessagesProcessor] Failed to auto-fetch outbound email content:`, fetchError);
-              // Continue processing - email can be fetched later
-              messageDoc.body = message.body || '';
-            }
-          } else {
-            messageDoc.body = message.body || '';
-            messageDoc.htmlBody = message.htmlBody;
-          }
-          break;
-          
-        case 4: // WhatsApp
-          messageDoc.body = message.body || '';
-          messageDoc.mediaUrl = message.mediaUrl;
-          messageDoc.mediaType = message.mediaType;
-          break;
-          
-        default:
-          messageDoc.body = message.body || '';
-          messageDoc.meta = message.meta || {};
-      }
-    } else {
-      // Fallback for messages without proper structure
-      messageDoc.body = payload.webhookPayload?.body || '';
-    }
+   // Handle different message types
+   if (message) {
+     switch (message.type) {
+       case 1: // SMS
+         messageDoc.body = message.body || '';
+         messageDoc.status = message.status || 'sent';
+         messageDoc.segments = message.segments || 1;
+         break;
+         
+       case 3: // Email
+         messageDoc.subject = message.subject || 'No subject';
+         
+         // Check if we have email message ID for content fetch
+         if (message.meta?.email?.messageIds?.[0]) {
+           messageDoc.emailMessageId = message.meta.email.messageIds[0];
+           messageDoc.needsContentFetch = true;
+           
+           // NEW: AUTO-FETCH EMAIL CONTENT FOR OUTBOUND
+           try {
+             const emailContent = await this.fetchEmailContent(
+               message.meta.email.messageIds[0], 
+               locationId
+             );
+             
+             if (emailContent) {
+               messageDoc.body = emailContent.body;
+               messageDoc.htmlBody = emailContent.htmlBody;
+               messageDoc.subject = emailContent.subject;
+               messageDoc.needsContentFetch = false;
+               messageDoc.emailFetchedAt = new Date();
+               console.log(`[MessagesProcessor] Outbound email content auto-fetched for ${message.meta.email.messageIds[0]}`);
+             }
+           } catch (fetchError) {
+             console.error(`[MessagesProcessor] Failed to auto-fetch outbound email content:`, fetchError);
+             // Continue processing - email can be fetched later
+             messageDoc.body = message.body || '';
+           }
+         } else {
+           messageDoc.body = message.body || '';
+           messageDoc.htmlBody = message.htmlBody;
+         }
+         break;
+         
+       case 4: // WhatsApp
+         messageDoc.body = message.body || '';
+         messageDoc.mediaUrl = message.mediaUrl;
+         messageDoc.mediaType = message.mediaType;
+         break;
+         
+       default:
+         messageDoc.body = message.body || '';
+         messageDoc.meta = message.meta || {};
+     }
+   } else {
+     // Fallback for messages without proper structure
+     messageDoc.body = payload.webhookPayload?.body || '';
+   }
 
-    await this.db.collection('messages').insertOne(messageDoc);
-  }
+   await this.db.collection('messages').insertOne(messageDoc);
+ }
 
-  /**
-   * Process conversation unread update
-   */
-  private async processConversationUpdate(payload: any, webhookId: string): Promise<void> {
-    // Handle nested structure
-    let locationId, conversationId, unreadCount;
-    
-    if (payload.webhookPayload) {
-      const webhookData = payload.webhookPayload;
-      locationId = payload.locationId || webhookData.locationId;
-      conversationId = webhookData.conversationId;
-      unreadCount = webhookData.unreadCount;
-    } else {
-      ({ locationId, conversationId, unreadCount } = payload);
-    }
-    
-    if (!locationId || !conversationId) {
-      console.warn(`[MessagesProcessor] Missing required fields for conversation update`);
-      return;
-    }
-    
-    await this.db.collection('conversations').updateOne(
-      {
-        ghlConversationId: conversationId,
-        locationId
-      },
-      {
-        $set: {
-          unreadCount: unreadCount || 0,
-          updatedAt: new Date()
-        }
-      }
-    );
-  }
+ /**
+  * Process conversation unread update
+  */
+ private async processConversationUpdate(payload: any, webhookId: string): Promise<void> {
+   // Handle nested structure
+   let locationId, conversationId, unreadCount;
+   
+   if (payload.webhookPayload) {
+     const webhookData = payload.webhookPayload;
+     locationId = payload.locationId || webhookData.locationId;
+     conversationId = webhookData.conversationId;
+     unreadCount = webhookData.unreadCount;
+   } else {
+     ({ locationId, conversationId, unreadCount } = payload);
+   }
+   
+   if (!locationId || !conversationId) {
+     console.warn(`[MessagesProcessor] Missing required fields for conversation update`);
+     return;
+   }
+   
+   await this.db.collection('conversations').updateOne(
+     {
+       ghlConversationId: conversationId,
+       locationId
+     },
+     {
+       $set: {
+         unreadCount: unreadCount || 0,
+         updatedAt: new Date()
+       }
+     }
+   );
+ }
 
-  /**
-   * Process LC Email Stats
-   */
-  private async processLCEmailStats(payload: any, webhookId: string): Promise<void> {
-    // Handle nested structure for LCEmailStats
-    let locationId, event, id, timestamp, message;
-    
-    if (payload.webhookPayload) {
-      // Native webhook format - the whole webhookPayload contains the email data
-      const webhookData = payload.webhookPayload;
-      locationId = payload.locationId;
-      event = webhookData.event || webhookData['log-level']; // Sometimes event is in log-level
-      id = webhookData.id || webhookData['email_message_id'];
-      timestamp = webhookData.timestamp || payload.timestamp;
-      message = webhookData.message || webhookData;
-    } else {
-      // Direct format
-      ({ locationId, event, id, timestamp, message } = payload);
-    }
-    
-    console.log(`[MessagesProcessor] Processing LCEmailStats event: ${event}`);
-    console.log(`[MessagesProcessor] LCEmailStats data:`, { locationId, event, id });
-    
-    if (!locationId || !event || !id) {
-      console.warn(`[MessagesProcessor] Missing required fields for LCEmailStats:`, {
-        locationId: !!locationId,
-        event: !!event,
-        id: !!id,
-        webhookPayload: payload.webhookPayload
-      });
-      return;
-    }
+ /**
+  * Process LC Email Stats
+  */
+ private async processLCEmailStats(payload: any, webhookId: string): Promise<void> {
+   // Handle nested structure for LCEmailStats
+   let locationId, event, id, timestamp, message;
+   
+   if (payload.webhookPayload) {
+     // Native webhook format - the whole webhookPayload contains the email data
+     const webhookData = payload.webhookPayload;
+     locationId = payload.locationId;
+     event = webhookData.event || webhookData['log-level']; // Sometimes event is in log-level
+     id = webhookData.id || webhookData['email_message_id'];
+     timestamp = webhookData.timestamp || payload.timestamp;
+     message = webhookData.message || webhookData;
+   } else {
+     // Direct format
+     ({ locationId, event, id, timestamp, message } = payload);
+   }
+   
+   console.log(`[MessagesProcessor] Processing LCEmailStats event: ${event}`);
+   console.log(`[MessagesProcessor] LCEmailStats data:`, { locationId, event, id });
+   
+   if (!locationId || !event || !id) {
+     console.warn(`[MessagesProcessor] Missing required fields for LCEmailStats:`, {
+       locationId: !!locationId,
+       event: !!event,
+       id: !!id,
+       webhookPayload: payload.webhookPayload
+     });
+     return;
+   }
 
-    // Store email event stats
-    await this.db.collection('email_stats').insertOne({
-      _id: new ObjectId(),
-      webhookId,
-      locationId,
-      emailId: id,
-      event: event, // 'delivered', 'opened', 'clicked', 'bounced', etc.
-      timestamp: new Date(timestamp || Date.now()),
-      recipient: message?.recipient || payload.webhookPayload?.recipient,
-      recipientDomain: message?.['recipient-domain'] || payload.webhookPayload?.['recipient-domain'],
-      primaryDomain: message?.['primary-dkim'] || payload.webhookPayload?.['primary-dkim'],
-      tags: message?.tags || payload.webhookPayload?.tags || [],
-      recipientProvider: message?.['recipient-provider'] || payload.webhookPayload?.['recipient-provider'],
-      campaigns: message?.campaigns || payload.webhookPayload?.campaigns || [],
-      deliveryStatus: message?.['delivery-status'] || payload.webhookPayload?.['delivery-status'],
-      envelope: message?.envelope || payload.webhookPayload?.envelope,
-      lcOperations: message?.['lc-operations'] || payload.webhookPayload?.['lc-operations'],
-      logLevel: message?.['log-level'] || payload.webhookPayload?.['log-level'],
-      metadata: payload,
-      processedAt: new Date(),
-      processedBy: 'queue'
-    });
+   // Store email event stats
+   await this.db.collection('email_stats').insertOne({
+     _id: new ObjectId(),
+     webhookId,
+     locationId,
+     emailId: id,
+     event: event, // 'delivered', 'opened', 'clicked', 'bounced', etc.
+     timestamp: new Date(timestamp || Date.now()),
+     recipient: message?.recipient || payload.webhookPayload?.recipient,
+     recipientDomain: message?.['recipient-domain'] || payload.webhookPayload?.['recipient-domain'],
+     primaryDomain: message?.['primary-dkim'] || payload.webhookPayload?.['primary-dkim'],
+     tags: message?.tags || payload.webhookPayload?.tags || [],
+     recipientProvider: message?.['recipient-provider'] || payload.webhookPayload?.['recipient-provider'],
+     campaigns: message?.campaigns || payload.webhookPayload?.campaigns || [],
+     deliveryStatus: message?.['delivery-status'] || payload.webhookPayload?.['delivery-status'],
+     envelope: message?.envelope || payload.webhookPayload?.envelope,
+     lcOperations: message?.['lc-operations'] || payload.webhookPayload?.['lc-operations'],
+     logLevel: message?.['log-level'] || payload.webhookPayload?.['log-level'],
+     metadata: payload,
+     processedAt: new Date(),
+     processedBy: 'queue'
+   });
 
-    // Update conversation/message with email status if we can find it
-    if (id) {
-      await this.db.collection('messages').updateOne(
-        { emailMessageId: id },
-        { 
-          $set: { 
-            emailStatus: event,
-            emailStatusUpdatedAt: new Date(),
-            [`emailEvents.${event}`]: new Date(timestamp || Date.now())
-          }
-        }
-      );
-    }
+   // Update conversation/message with email status if we can find it
+   if (id) {
+     await this.db.collection('messages').updateOne(
+       { emailMessageId: id },
+       { 
+         $set: { 
+           emailStatus: event,
+           emailStatusUpdatedAt: new Date(),
+           [`emailEvents.${event}`]: new Date(timestamp || Date.now())
+         }
+       }
+     );
+   }
 
-    console.log(`[MessagesProcessor] LCEmailStats processed: ${event} for ${id}`);
-  }
+   console.log(`[MessagesProcessor] LCEmailStats processed: ${event} for ${id}`);
+ }
 
-  /**
-   * NEW: Fetch email content from GHL
-   */
-  private async fetchEmailContent(emailMessageId: string, locationId: string): Promise<{ body: string; htmlBody: string; subject: string } | null> {
-    try {
-      // Get location for auth
-      const location = await this.db.collection('locations').findOne({ locationId });
-      
-      if (!location) {
-        console.error(`[MessagesProcessor] Location not found for email fetch: ${locationId}`);
-        return null;
-      }
+ /**
+  * NEW: Fetch email content from GHL
+  */
+ private async fetchEmailContent(emailMessageId: string, locationId: string): Promise<{ body: string; htmlBody: string; subject: string } | null> {
+   try {
+     // Get location for auth
+     const location = await this.db.collection('locations').findOne({ locationId });
+     
+     if (!location) {
+       console.error(`[MessagesProcessor] Location not found for email fetch: ${locationId}`);
+       return null;
+     }
 
-      // Get auth header
-      const auth = await getAuthHeader(location);
+     // Get auth header
+     const auth = await getAuthHeader(location);
 
-      // Fetch email content from GHL
-      console.log(`[MessagesProcessor] Fetching email content for ${emailMessageId}`);
-      
-      const response = await axios.get(
-        `https://services.leadconnectorhq.com/conversations/messages/email/${emailMessageId}`,
-        {
-          headers: {
-            'Authorization': auth.header,
-            'Version': '2021-04-15',
-            'Accept': 'application/json'
-          },
-          timeout: 10000 // 10 second timeout
-        }
-      );
+     // Fetch email content from GHL
+     console.log(`[MessagesProcessor] Fetching email content for ${emailMessageId}`);
+     
+     const response = await axios.get(
+       `https://services.leadconnectorhq.com/conversations/messages/email/${emailMessageId}`,
+       {
+         headers: {
+           'Authorization': auth.header,
+           'Version': '2021-04-15',
+           'Accept': 'application/json'
+         },
+         timeout: 10000 // 10 second timeout
+       }
+     );
 
-      const emailData = response.data.emailMessage;
-      
-      if (!emailData) {
-        console.warn(`[MessagesProcessor] No email data returned for ${emailMessageId}`);
-        return null;
-      }
+     const emailData = response.data.emailMessage;
+     
+     if (!emailData) {
+       console.warn(`[MessagesProcessor] No email data returned for ${emailMessageId}`);
+       return null;
+     }
 
-      return {
-        subject: emailData.subject || 'No subject',
-        body: emailData.body || '',
-        htmlBody: emailData.htmlBody || emailData.body || ''
-      };
-    } catch (error: any) {
-      // Don't log full error to avoid exposing tokens
-      console.error(`[MessagesProcessor] Failed to fetch email content for ${emailMessageId}:`, {
-        status: error.response?.status,
-        statusText: error.response?.statusText,
-        message: error.message
-      });
-      return null;
-    }
-  }
+     return {
+       subject: emailData.subject || 'No subject',
+       body: emailData.body || '',
+       htmlBody: emailData.htmlBody || emailData.body || ''
+     };
+   } catch (error: any) {
+     // Don't log full error to avoid exposing tokens
+     console.error(`[MessagesProcessor] Failed to fetch email content for ${emailMessageId}:`, {
+       status: error.response?.status,
+       statusText: error.response?.statusText,
+       message: error.message
+     });
+     return null;
+   }
+ }
 
-  /**
-   * Get conversation type from message type
-   */
-  private getConversationType(messageType: number): string {
-    const typeMap: Record<number, string> = {
-      1: 'TYPE_PHONE',
-      3: 'TYPE_EMAIL',
-      4: 'TYPE_WHATSAPP',
-      5: 'TYPE_GMB',
-      6: 'TYPE_FB',
-      7: 'TYPE_IG'
-    };
-    
-    return typeMap[messageType] || 'TYPE_OTHER';
-  }
+ /**
+  * Get conversation type from message type
+  */
+ private getConversationType(messageType: number): string {
+   const typeMap: Record<number, string> = {
+     1: 'TYPE_PHONE',
+     3: 'TYPE_EMAIL',
+     4: 'TYPE_WHATSAPP',
+     5: 'TYPE_GMB',
+     6: 'TYPE_FB',
+     7: 'TYPE_IG'
+   };
+   
+   return typeMap[messageType] || 'TYPE_OTHER';
+ }
 
-  /**
-   * Get message type name from type number
-   */
-  private getMessageTypeName(type: number): string {
-    const typeMap: Record<number, string> = {
-      1: 'SMS',
-      3: 'Email',
-      4: 'WhatsApp',
-      5: 'Google My Business',
-      6: 'Facebook',
-      7: 'Instagram',
-      24: 'Activity - Appointment',
-      25: 'Activity - Contact',
-      26: 'Activity - Invoice',
-      27: 'Activity - Opportunity'
-    };
-    
-    return typeMap[type] || `Type ${type}`;
-  }
+ /**
+  * Get message type name from type number
+  */
+ private getMessageTypeName(type: number): string {
+   const typeMap: Record<number, string> = {
+     1: 'SMS',
+     3: 'Email',
+     4: 'WhatsApp',
+     5: 'Google My Business',
+     6: 'Facebook',
+     7: 'Instagram',
+     24: 'Activity - Appointment',
+     25: 'Activity - Contact',
+     26: 'Activity - Invoice',
+     27: 'Activity - Opportunity'
+   };
+   
+   return typeMap[type] || `Type ${type}`;
+ }
 }


### PR DESCRIPTION
- Changed contactId to contactObjectId (ObjectId) in conversations/messages
- Store conversationId as ObjectId in messages collection
- Add ghlContactId and ghlConversationId for GHL references
- Update all backend endpoints and processors
- Add comprehensive documentation for the new schema